### PR TITLE
Add wildcard to ignore all themes besides the default theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ config.yml
 string_overrides.yml
 server*.log
 site/
+themes/**/*
+!themes/default/**/*


### PR DESCRIPTION
Just so if anyone wants to create a theme then they can do so without causing any issues. People could than create themes that could be added and whitelisted from the ignore list.